### PR TITLE
Handling proxies and on the fly map projection

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -41,7 +41,6 @@ class OSMEditorRemoteControlPlugin:
     else:
       extent = self.getLonLatExtent()
       self.action.setEnabled(extent.width() * extent.height() < MAX_DOWLOAD_AREA_DEG)
-      print extent.width() * extent.height()
   def run(self):
     extent = self.getLonLatExtent()
     url = 'http://localhost:8111/load_and_zoom?left=%f&right=%f&top=%f&bottom=%f' % (extent.xMinimum(), extent.xMaximum(), extent.yMaximum(), extent.yMinimum())


### PR DESCRIPTION
A couple of improvements:
- force urllib to skip proxy (couldn't use the tool behind a corporate proxy)
- now supports on-the-fly map reprojection, and converts to epsg 4326 only when needed
